### PR TITLE
Add new notification type NotificationRaw that is called every time a…

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -2345,6 +2345,11 @@ void Driver::ProcessMsg
 				Log::Write( LogLevel_Detail, _data[3], "  Message transaction complete" );
 				Log::Write( LogLevel_Detail, "" );
 
+				Notification* notification2 = new Notification( Notification::Type_NotificationRaw );
+				notification2->SetHomeAndNodeIds( m_homeId, _data[3] );
+				notification2->SetRaw(_data);
+				QueueNotification( notification2 );
+				
 				if( m_notifytransactions )
 				{
 					Notification* notification = new Notification( Notification::Type_Notification );

--- a/cpp/src/Notification.cpp
+++ b/cpp/src/Notification.cpp
@@ -223,9 +223,12 @@ string Notification::GetAsString() const {
 					break;
 			}
 			break;
-			case Type_NodeReset:
-				str = "Node Reset";
-				break;
+		case Type_NodeReset:
+			str = "Node Reset";
+			break;
+		case Type_NotificationRaw:
+			str = "NotificationRaw";
+			break;
 	}
 	return str;
 

--- a/cpp/src/Notification.h
+++ b/cpp/src/Notification.h
@@ -31,6 +31,9 @@
 #include "Defs.h"
 #include "value_classes/ValueID.h"
 
+#include <stdlib.h>
+#include <vector>
+
 namespace OpenZWave
 {
 	/** \brief Provides a container for data sent via the notification callback
@@ -94,7 +97,8 @@ namespace OpenZWave
 			Type_DriverRemoved,					/**< The Driver is being removed. (either due to Error or by request) Do Not Call Any Driver Related Methods after receiving this call */
 			Type_ControllerCommand,				/**< When Controller Commands are executed, Notifications of Success/Failure etc are communicated via this Notification
 												  * Notification::GetEvent returns Driver::ControllerState and Notification::GetNotification returns Driver::ControllerError if there was a error */
-			Type_NodeReset						/**< The Device has been reset and thus removed from the NodeList in OZW */
+			Type_NodeReset,						/**< The Device has been reset and thus removed from the NodeList in OZW */
+			Type_NotificationRaw			/**< When a message is complete this notification is used to send the complete raw message */
 		};
 
 		/**
@@ -181,6 +185,16 @@ namespace OpenZWave
 		 */
 		string GetAsString()const;
 
+		string GetRawString()const{
+			vector<uint8_t>::size_type size = m_raw.size();
+			char converted[size * 2 + 1];
+
+			for(vector<uint8_t>::size_type i = 0; i != size; i++) {
+				sprintf( &converted[i*2], "%02X", m_raw[i] );
+			}
+
+			return converted;
+		}
 
 	private:
 		Notification( NotificationType _type ): m_type( _type ), m_byte(0), m_event(0) {}
@@ -194,14 +208,15 @@ namespace OpenZWave
 		void SetSceneId( uint8 const _sceneId ){ assert(Type_SceneEvent==m_type); m_byte = _sceneId; }
 		void SetButtonId( uint8 const _buttonId ){ assert(Type_CreateButton==m_type||Type_DeleteButton==m_type||Type_ButtonOn==m_type||Type_ButtonOff==m_type); m_byte = _buttonId; }
 		void SetNotification( uint8 const _noteId ){ assert((Type_Notification==m_type) || (Type_ControllerCommand == m_type)); m_byte = _noteId; }
+		void SetRaw( uint8* _raw){ m_raw.assign(&_raw[0], &_raw[sizeof(_raw)]);	}
 
-		NotificationType		m_type;
-		ValueID				m_valueId;
-		uint8				m_byte;
-		uint8				m_event;
+		NotificationType			m_type;
+		ValueID								m_valueId;
+		uint8									m_byte;
+		uint8									m_event;
+		vector<uint8_t>				m_raw;
 	};
 
 } //namespace OpenZWave
 
 #endif //_Notification_H
-


### PR DESCRIPTION
… message is complete regardless of whether or not m_notifytransactions is set to true. It can then be handled on by whatever subscriber to get Notification.GetRawString() to get a string of hex values that can be used in whatever way necessary.